### PR TITLE
Remove host with hyphens

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,6 @@ function match (route) {
   return route.trim()
     .replace(/[\?|#].*$/, '')
     .replace(/^(?:https?\:)\/\//, '')
-    .replace(/^(?:[\w.])+(?:[\:0-9]{4,5})?/, '')
+    .replace(/^(?:[\w+(?:-\w+)+.])+(?:[\:0-9]{4,5})?/, '')
     .replace(/\/$/, '')
 }

--- a/test.js
+++ b/test.js
@@ -33,8 +33,10 @@ test('it should remove protocols', function (t) {
 })
 
 test('it should remove hosts', function (t) {
-  t.plan(1)
+  t.plan(3)
   t.equal(match('bar.com/foo/bar/'), '/foo/bar')
+  t.equal(match('bar-foo.com/foo/bar/'), '/foo/bar')
+  t.equal(match('bar-foo--bar.com/foo/bar/'), '/foo/bar')
 })
 
 test('it should remove ips', function (t) {


### PR DESCRIPTION
Found a weird error while using sheet-router. It didn't like hyphens:

```
> const pathname = require('pathname-match')
undefined
> pathname('http://foo-bar.com/baz')
'-bar.com/baz
```
