### PR TITLE
Use var instead of const

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const assert = require('assert')
+var assert = require('assert')
 
 module.exports = match
 


### PR DESCRIPTION
`const` is not supported by older browsers